### PR TITLE
fix some typo

### DIFF
--- a/docs/CH14.md
+++ b/docs/CH14.md
@@ -297,7 +297,7 @@ public class StreamDemo {
 
 ### 14.2.2 FileInputStream、FileOutputStream
 
-java.io.FileInputStream 是 InputStream 的子類，由開頭 File 名稱上就可以知道，FileInputStream 與從指定的檔案中讀取資料至目的地有關，而 java.io.FileOutputStream 是 OutputStream 的子類，顧名思義，FileOnputStream 主要與從來源地寫入資料至指定的檔案中有關。
+java.io.FileInputStream 是 InputStream 的子類，由開頭 File 名稱上就可以知道，FileInputStream 與從指定的檔案中讀取資料至目的地有關，而 java.io.FileOutputStream 是 OutputStream 的子類，顧名思義，FileOutputStream 主要與從來源地寫入資料至指定的檔案中有關。
 
 當您建立一個 FileInputStream 或 FileOutputStream 的實例時，必須指定檔案位置及檔案名稱，實例被建立時檔案的串流就會開啟，而不使用串流時，您必須關閉檔案串流，以釋放與串流相依的系統資源，完成檔案讀寫的動作。
 
@@ -751,7 +751,7 @@ public class ObjectStreamDemo {
     momor   103
     becky   104
 
-注意在試圖將物件附加至一個先前已寫入物件的檔案時，由於 ObjectOutputStream 在寫入資料時，還會加上一個特別的串流頭（Stream header），而讀取檔案時會檢查這個串流頭，如果一個檔案中被多次附加物件，那麼該檔案中會有多個串流頭，如此讀取檢查時就會發現不一致，這會丟出 java.io.StreamCorrupedException，為了解決這個問題，您可以重新定義 ObjectOutputStream 的 writeStreamHeader() 方法，如果是以附加的方式來寫入物件，就不寫入串流頭：
+注意在試圖將物件附加至一個先前已寫入物件的檔案時，由於 ObjectOutputStream 在寫入資料時，還會加上一個特別的串流頭（Stream header），而讀取檔案時會檢查這個串流頭，如果一個檔案中被多次附加物件，那麼該檔案中會有多個串流頭，如此讀取檢查時就會發現不一致，這會丟出 java.io.StreamCorruptedException，為了解決這個問題，您可以重新定義 ObjectOutputStream 的 writeStreamHeader() 方法，如果是以附加的方式來寫入物件，就不寫入串流頭：
 
     ObjectOutputStream objOutputStream = 
         new ObjectOutputStream(
@@ -973,7 +973,7 @@ public class PrintStreamDemo {
 
 ### 14.2.8 ByteArrayInputStream、ByteArrayOutputStream
 
-串流的來源或目的地不一定是檔案，也可以是記憶體中的一個空間，例如一個位元陣列，java.io.ByteArrayInputStream、java.io.ByteArray OutputStream 即是將位元陣列當作串流輸入來源、輸出目的地的類別。
+串流的來源或目的地不一定是檔案，也可以是記憶體中的一個空間，例如一個位元陣列，java.io.ByteArrayInputStream、java.io.ByteArrayOutputStream 即是將位元陣列當作串流輸入來源、輸出目的地的類別。
 
 ByteArrayInputStream 可以將一個陣列當作串流輸入的來源，而 ByteArrayOutputStream 則可以將一個位元陣列當作串流輸出的目的地，在這邊舉一個簡單的檔案位元編輯程式作為例子，您可以開啟一個簡單的文字檔案，當中有簡單的 ABCDEFG 等字元，在讀取檔案之後，您可以直接以程式來指定檔案中位元的位置來修改所指定的字元，作法是將檔案讀入陣列中，指定陣列索引修改元素，然後重新將陣列存回檔案，範例 14.14 是實作的程式內容。
 


### PR DESCRIPTION
修改拼寫錯誤
1. 正確的拼寫為 FileOutputStream
2. 正確的拼寫為 java.io.StreamCorruptedException 
![image](https://user-images.githubusercontent.com/3983683/46343626-fd1d6900-c670-11e8-9cd9-8a3e7d6949c7.png)
3. 正確的拼寫為 ByteArrayOutputStream (原文中多了一個空白字元)